### PR TITLE
Downgrade from 452 to 45

### DIFF
--- a/src/SparkPost/Properties/AssemblyInfo.cs
+++ b/src/SparkPost/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.*")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/src/SparkPost/SparkPost.nuspec
+++ b/src/SparkPost/SparkPost.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>1.0.1</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/src/SparkPost/SparkPost.nuspec
+++ b/src/SparkPost/SparkPost.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright 2016</copyright>
     <tags>email</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="6.0" />
+      <dependency id="Newtonsoft.Json" version="(6.0,)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This is meant to allow the library to work with 4.5 and greater.

I don't know if these changes specifically did it, though.  Perhaps the versioning update fixed it, or perhaps the previous build was just against 4.5.2.  But the main point is that the lib was assigned to "45" instead of "452" so it seems to work.

![fullscreen_031816_073827_am](https://cloud.githubusercontent.com/assets/148768/13878055/c6bbb45e-ecdc-11e5-90e2-cb9601e93804.jpg)
