### PR TITLE
Force type handling to off

### DIFF
--- a/src/SparkPost/RequestSender.cs
+++ b/src/SparkPost/RequestSender.cs
@@ -22,9 +22,7 @@ namespace SparkPost
                 c.DefaultRequestHeaders.Accept.Clear();
                 c.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
 
-                var settings = new JsonSerializerSettings {TypeNameHandling = TypeNameHandling.None};
-                var result = await c.PostAsync(request.Url,
-                    new StringContent(JsonConvert.SerializeObject(request.Data, settings)));
+                var result = await c.PostAsync(request.Url, BuildContent(request.Data));
 
                 return new Response
                 {
@@ -33,6 +31,11 @@ namespace SparkPost
                     Content = await result.Content.ReadAsStringAsync(),
                 };
             }
+        }
+
+        private static StringContent BuildContent(object data)
+        {
+            return new StringContent(JsonConvert.SerializeObject(data, new JsonSerializerSettings {TypeNameHandling = TypeNameHandling.None}));
         }
     }
 }

--- a/src/SparkPost/RequestSender.cs
+++ b/src/SparkPost/RequestSender.cs
@@ -22,8 +22,9 @@ namespace SparkPost
                 c.DefaultRequestHeaders.Accept.Clear();
                 c.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
 
+                var settings = new JsonSerializerSettings();
                 var result = await c.PostAsync(request.Url,
-                    new StringContent(JsonConvert.SerializeObject(request.Data)));
+                    new StringContent(JsonConvert.SerializeObject(request.Data, settings)));
 
                 return new Response
                 {

--- a/src/SparkPost/RequestSender.cs
+++ b/src/SparkPost/RequestSender.cs
@@ -22,7 +22,7 @@ namespace SparkPost
                 c.DefaultRequestHeaders.Accept.Clear();
                 c.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
 
-                var settings = new JsonSerializerSettings();
+                var settings = new JsonSerializerSettings {TypeNameHandling = TypeNameHandling.None};
                 var result = await c.PostAsync(request.Url,
                     new StringContent(JsonConvert.SerializeObject(request.Data, settings)));
 


### PR DESCRIPTION
This is meant to resolve #17 .

So, apparently JSON.Net has global settings that can change how it operates.  People that change these global settings could inadvertently break how this library works.

This library's needs for json serialization were meant to run with the default settings, so I've passed those to get JSON.Net to ignore the global settings.  