### PR TITLE
Add support for CC and BCC

### DIFF
--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -335,6 +335,57 @@ namespace SparkPost.Tests
                     .CastAs<IDictionary<string, string>>()
                     [key].ShouldEqual(value);
             }
+
+            [Test]
+            public void It_should_not_set_the_cc_if_there_are_no_cc_emails()
+            {
+                var key = Guid.NewGuid().ToString();
+                var value = Guid.NewGuid().ToString();
+
+                var recipient1 = new Recipient {Type = RecipientType.To, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                var recipient2 = new Recipient {Type = RecipientType.BCC, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                transmission.Recipients = new List<Recipient> {recipient1, recipient2};
+
+                transmission.Content.Headers[key] = value;
+
+                 mapper.ToDictionary(transmission)
+                    ["content"]
+                    .CastAs<IDictionary<string, object>>()
+                    ["headers"]
+                    .CastAs<IDictionary<string, string>>()
+                    .ContainsKey("CC")
+                    .ShouldBeFalse();
+            }
+
+            [Test]
+            public void It_should_not_set_a_header_value_if_there_are_no_ccs()
+            {
+                var recipient1 = new Recipient {Type = RecipientType.To, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                var recipient2 = new Recipient {Type = RecipientType.BCC, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                transmission.Recipients = new List<Recipient> {recipient1, recipient2};
+
+                 mapper.ToDictionary(transmission)
+                    ["content"]
+                    .CastAs<IDictionary<string, object>>()
+                    .ContainsKey("headers")
+                    .ShouldBeFalse();
+            }
+
+            [Test]
+            public void It_should_ignore_empty_ccs()
+            {
+                var recipient1 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = ""}};
+                var recipient2 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = null}};
+                var recipient3 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = " "}};
+                transmission.Recipients = new List<Recipient> {recipient1, recipient2, recipient3};
+
+                 mapper.ToDictionary(transmission)
+                    ["content"]
+                    .CastAs<IDictionary<string, object>>()
+                    .ContainsKey("headers")
+                    .ShouldBeFalse();
+            }
+
         }
 
         [TestFixture]

--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -286,6 +286,39 @@ namespace SparkPost.Tests
         }
 
         [TestFixture]
+        public class MappingCcFields
+        {
+            [SetUp]
+            public void Setup()
+            {
+                transmission = new Transmission();
+                mapper = new DataMapper("v1");
+            }
+
+            private Transmission transmission;
+            private DataMapper mapper;
+
+            [Test]
+            public void It_should_set_the_CC_Header_for_the_cc_emails()
+            {
+                var recipient1 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                var recipient2 = new Recipient {Type = RecipientType.To, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                var recipient3 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = Guid.NewGuid().ToString()}};
+
+                transmission.Recipients = new List<Recipient> {recipient1, recipient2, recipient3};
+
+                var cc = mapper.ToDictionary(transmission)
+                    ["content"]
+                    .CastAs<IDictionary<string, object>>()
+                    ["headers"]
+                    .CastAs<IDictionary<string, string>>()
+                    ["CC"];
+
+                cc.ShouldEqual("<" + recipient1.Address.Email + ">,<" + recipient3.Address.Email + ">");
+            }
+        }
+
+        [TestFixture]
         public class ContentMappingTests
         {
             [SetUp]

--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -316,6 +316,25 @@ namespace SparkPost.Tests
 
                 cc.ShouldEqual("<" + recipient1.Address.Email + ">,<" + recipient3.Address.Email + ">");
             }
+
+            [Test]
+            public void It_should_not_overwrite_any_existing_headers()
+            {
+                var key = Guid.NewGuid().ToString();
+                var value = Guid.NewGuid().ToString();
+
+                var recipient1 = new Recipient {Type = RecipientType.CC, Address = new Address {Email = Guid.NewGuid().ToString()}};
+                transmission.Recipients = new List<Recipient> {recipient1};
+
+                transmission.Content.Headers[key] = value;
+
+                 mapper.ToDictionary(transmission)
+                    ["content"]
+                    .CastAs<IDictionary<string, object>>()
+                    ["headers"]
+                    .CastAs<IDictionary<string, string>>()
+                    [key].ShouldEqual(value);
+            }
         }
 
         [TestFixture]

--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -102,6 +102,13 @@ namespace SparkPost.Tests
             {
                 mapper.ToDictionary(recipient).Keys.ShouldNotContain("substitution_data");
             }
+
+            [Test]
+            public void The_type_should_be_ignored()
+            {
+                recipient.Type = RecipientType.CC;
+                mapper.ToDictionary(recipient).Keys.ShouldNotContain("type");
+            }
         }
 
         [TestFixture]

--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -386,6 +386,19 @@ namespace SparkPost.Tests
                     .ShouldBeFalse();
             }
 
+            [Test]
+            public void It_should_ignore_any_cc_recipients_with_no_address()
+            {
+                var recipient1 = new Recipient {Type = RecipientType.CC, Address = null};
+                transmission.Recipients = new List<Recipient> {recipient1};
+
+                 mapper.ToDictionary(transmission)
+                    ["content"]
+                    .CastAs<IDictionary<string, object>>()
+                    .ContainsKey("headers")
+                    .ShouldBeFalse();
+            }
+
         }
 
         [TestFixture]

--- a/src/SparkPost/CcHandling.cs
+++ b/src/SparkPost/CcHandling.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace SparkPost
+{
+    internal static class CcHandling
+    {
+        internal static void SetAnyCCsInTheHeader(Transmission transmission, IDictionary<string, object> result)
+        {
+            var ccs = GetTheCcEmails(transmission);
+
+            if (ccs.Any() == false) return;
+
+            MakeSureThereIsAHeaderDefinedInTheRequest(result);
+
+            SetThisHeaderValue(result, "CC", FormatTheCCs(ccs));
+        }
+
+        private static string FormatTheCCs(IEnumerable<string> ccs)
+        {
+            return string.Join(",", ccs.Select(x => "<" + x + ">"));
+        }
+
+        private static IEnumerable<string> GetTheCcEmails(Transmission transmission)
+        {
+            return transmission.Recipients
+                .Where(x => x.Type == RecipientType.CC)
+                .Where(x => x.Address != null)
+                .Where(x => string.IsNullOrWhiteSpace(x.Address.Email) == false)
+                .Select(x => x.Address.Email);
+        }
+
+        private static void MakeSureThereIsAHeaderDefinedInTheRequest(IDictionary<string, object> result)
+        {
+            if (result.ContainsKey("content") == false)
+                result["content"] = new Dictionary<string, object>();
+
+            var content = result["content"] as IDictionary<string, object>;
+            if (content.ContainsKey("headers") == false)
+                content["headers"] = new Dictionary<string, string>();
+        }
+
+        private static void SetThisHeaderValue(IDictionary<string, object> result, string key, string value)
+        {
+            ((IDictionary<string, string>) ((IDictionary<string, object>) result["content"])["headers"])
+                [key] = value;
+        }
+    }
+}

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -29,7 +29,10 @@ namespace SparkPost
 
         public virtual IDictionary<string, object> ToDictionary(Recipient recipient)
         {
-            return WithCommonConventions(recipient);
+            return WithCommonConventions(recipient, new Dictionary<string, object>()
+            {
+                ["type"] = null,
+            });
         }
 
         public virtual IDictionary<string, object> ToDictionary(Address address)

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -171,8 +171,13 @@ namespace SparkPost
         private static void SetAnyCCsInTheHeader(Transmission transmission, IDictionary<string, object> result)
         {
             var ccAddresses =
-                transmission.Recipients.Where(x => x.Type == RecipientType.CC).Select(x => "<" + x.Address.Email + ">");
+                transmission.Recipients
+                .Where(x => x.Type == RecipientType.CC)
+                .Where(x => string.IsNullOrWhiteSpace(x.Address.Email) == false)
+                .Select(x => "<" + x.Address.Email + ">");
             var cc = string.Join(",", ccAddresses);
+
+            if (string.IsNullOrEmpty(cc)) return;
 
             if (result.ContainsKey("content") == false)
                 result["content"] = new Dictionary<string, object>();

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -26,17 +26,7 @@ namespace SparkPost
                     : transmission.Recipients.Select(ToDictionary)
             });
 
-            var ccAddresses = transmission.Recipients.Where(x => x.Type == RecipientType.CC).Select(x => "<" + x.Address.Email + ">");
-            var cc = string.Join(",", ccAddresses);
-
-            if (result.ContainsKey("content") == false)
-                result["content"] = new Dictionary<string, object>();
-
-            var content = result["content"] as IDictionary<string, object>;
-            if (content.ContainsKey("headers") == false)
-                content["headers"] = new Dictionary<string, string>();
-            var headers = content["headers"] as IDictionary<string, string>;
-            headers["CC"] = cc;
+            SetAnyCCsInTheHeader(transmission, result);
 
             return result;
         }
@@ -176,6 +166,22 @@ namespace SparkPost
                     TheMethod = x
                 }).ToList()
                 .ToDictionary(x => x.TheType, x => x.TheMethod);
+        }
+
+        private static void SetAnyCCsInTheHeader(Transmission transmission, IDictionary<string, object> result)
+        {
+            var ccAddresses =
+                transmission.Recipients.Where(x => x.Type == RecipientType.CC).Select(x => "<" + x.Address.Email + ">");
+            var cc = string.Join(",", ccAddresses);
+
+            if (result.ContainsKey("content") == false)
+                result["content"] = new Dictionary<string, object>();
+
+            var content = result["content"] as IDictionary<string, object>;
+            if (content.ContainsKey("headers") == false)
+                content["headers"] = new Dictionary<string, string>();
+            var headers = content["headers"] as IDictionary<string, string>;
+            headers["CC"] = cc;
         }
     }
 }

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -170,15 +170,13 @@ namespace SparkPost
 
         private static void SetAnyCCsInTheHeader(Transmission transmission, IDictionary<string, object> result)
         {
-            var ccAddresses =
-                transmission.Recipients
+            var ccAddresses = transmission.Recipients
                 .Where(x => x.Type == RecipientType.CC)
                 .Where(x => x.Address != null)
                 .Where(x => string.IsNullOrWhiteSpace(x.Address.Email) == false)
                 .Select(x => "<" + x.Address.Email + ">");
-            var cc = string.Join(",", ccAddresses);
 
-            if (string.IsNullOrEmpty(cc)) return;
+            if (ccAddresses.Any() == false) return;
 
             if (result.ContainsKey("content") == false)
                 result["content"] = new Dictionary<string, object>();
@@ -186,8 +184,9 @@ namespace SparkPost
             var content = result["content"] as IDictionary<string, object>;
             if (content.ContainsKey("headers") == false)
                 content["headers"] = new Dictionary<string, string>();
-            var headers = content["headers"] as IDictionary<string, string>;
-            headers["CC"] = cc;
+
+            ((IDictionary<string, string>)((IDictionary<string, object>) result["content"])["headers"])
+                ["CC"] = string.Join(",", ccAddresses);
         }
     }
 }

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -33,9 +33,10 @@ namespace SparkPost
                 result["content"] = new Dictionary<string, object>();
 
             var content = result["content"] as IDictionary<string, object>;
-            var headers = new Dictionary<string, string> {["CC"] = cc};
-            content["headers"] = headers;
-            result["content"] = content;
+            if (content.ContainsKey("headers") == false)
+                content["headers"] = new Dictionary<string, string>();
+            var headers = content["headers"] as IDictionary<string, string>;
+            headers["CC"] = cc;
 
             return result;
         }

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -173,6 +173,7 @@ namespace SparkPost
             var ccAddresses =
                 transmission.Recipients
                 .Where(x => x.Type == RecipientType.CC)
+                .Where(x => x.Address != null)
                 .Where(x => string.IsNullOrWhiteSpace(x.Address.Email) == false)
                 .Select(x => "<" + x.Address.Email + ">");
             var cc = string.Join(",", ccAddresses);

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -176,7 +176,12 @@ namespace SparkPost
 
             MakeSureThereIsAHeaderDefinedInTheRequest(result);
 
-            SetThisHeaderValue(result, "CC", string.Join(",", ccs));
+            SetThisHeaderValue(result, "CC", FormatTheCCs(ccs));
+        }
+
+        private static string FormatTheCCs(IEnumerable<string> ccs)
+        {
+            return string.Join(",", ccs.Select(x=> "<" + x + ">"));
         }
 
         private static IEnumerable<string> GetTheCcEmails(Transmission transmission)
@@ -185,7 +190,7 @@ namespace SparkPost
                 .Where(x => x.Type == RecipientType.CC)
                 .Where(x => x.Address != null)
                 .Where(x => string.IsNullOrWhiteSpace(x.Address.Email) == false)
-                .Select(x => "<" + x.Address.Email + ">");
+                .Select(x => x.Address.Email);
         }
 
         private static void MakeSureThereIsAHeaderDefinedInTheRequest(IDictionary<string, object> result)

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -26,7 +26,7 @@ namespace SparkPost
                     : transmission.Recipients.Select(ToDictionary)
             });
 
-            SetAnyCCsInTheHeader(transmission, result);
+            CcHandling.SetAnyCCsInTheHeader(transmission, result);
 
             return result;
         }
@@ -166,47 +166,6 @@ namespace SparkPost
                     TheMethod = x
                 }).ToList()
                 .ToDictionary(x => x.TheType, x => x.TheMethod);
-        }
-
-        private static void SetAnyCCsInTheHeader(Transmission transmission, IDictionary<string, object> result)
-        {
-            var ccs = GetTheCcEmails(transmission);
-
-            if (ccs.Any() == false) return;
-
-            MakeSureThereIsAHeaderDefinedInTheRequest(result);
-
-            SetThisHeaderValue(result, "CC", FormatTheCCs(ccs));
-        }
-
-        private static string FormatTheCCs(IEnumerable<string> ccs)
-        {
-            return string.Join(",", ccs.Select(x=> "<" + x + ">"));
-        }
-
-        private static IEnumerable<string> GetTheCcEmails(Transmission transmission)
-        {
-            return transmission.Recipients
-                .Where(x => x.Type == RecipientType.CC)
-                .Where(x => x.Address != null)
-                .Where(x => string.IsNullOrWhiteSpace(x.Address.Email) == false)
-                .Select(x => x.Address.Email);
-        }
-
-        private static void MakeSureThereIsAHeaderDefinedInTheRequest(IDictionary<string, object> result)
-        {
-            if (result.ContainsKey("content") == false)
-                result["content"] = new Dictionary<string, object>();
-
-            var content = result["content"] as IDictionary<string, object>;
-            if (content.ContainsKey("headers") == false)
-                content["headers"] = new Dictionary<string, string>();
-        }
-
-        private static void SetThisHeaderValue(IDictionary<string, object> result, string key, string value)
-        {
-            ((IDictionary<string, string>) ((IDictionary<string, object>) result["content"])["headers"])
-                [key] = value;
         }
     }
 }

--- a/src/SparkPost/Recipient.cs
+++ b/src/SparkPost/Recipient.cs
@@ -17,5 +17,7 @@ namespace SparkPost
         public IList<string> Tags { get; set; }
         public IDictionary<string, object> Metadata { get; set; }
         public IDictionary<string, object> SubstitutionData { get; set; }
+
+        public RecipientType Type { get; set; }
     }
 }

--- a/src/SparkPost/RecipientType.cs
+++ b/src/SparkPost/RecipientType.cs
@@ -1,0 +1,9 @@
+﻿namespace SparkPost
+{
+    public enum RecipientType
+    {
+        To,
+        CC,
+        BCC
+    }
+}

--- a/src/SparkPost/SparkPost.csproj
+++ b/src/SparkPost/SparkPost.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="Address.cs" />
     <Compile Include="Attachment.cs" />
+    <Compile Include="CcHandling.cs" />
     <Compile Include="Client.cs" />
     <Compile Include="Content.cs" />
     <Compile Include="DataMapper.cs" />

--- a/src/SparkPost/SparkPost.csproj
+++ b/src/SparkPost/SparkPost.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Options.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Recipient.cs" />
+    <Compile Include="RecipientType.cs" />
     <Compile Include="Request.cs" />
     <Compile Include="RequestSender.cs" />
     <Compile Include="Response.cs" />


### PR DESCRIPTION
BCC comes for free, as emails to multiple recipients are kept from each other.  But I'm keeping BCC option in there to avoid "how do I send BCC?" question... and in case some sort of solution is created around it.

CC is a little more awkward, as a user originally had to create a comma-separated list of CC'd email addresses from the list of recipients.  I changed this so that a ```RecipientType``` of To/CC/BCC can be set on a recipient.  So users won't have to deal with the header - the library will do all of the work.

![screenshot_032816_071547_am](https://cloud.githubusercontent.com/assets/148768/14077777/e3d2f360-f4b4-11e5-8ac4-f90206debd2a.jpg)
