### PR TITLE
Add interfaces for Client and Transmissions classes

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,4 +6,5 @@
 
 ## Patches and suggestions
 
+* Chris Charabaruk (https://github.com/coldacid) - SPEQit
 * ADD YOURSELF HERE (and link to your github page)

--- a/src/SparkPost.Portable/SparkPost.Portable.csproj
+++ b/src/SparkPost.Portable/SparkPost.Portable.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -53,8 +53,14 @@
     <Compile Include="..\SparkPost\File.cs">
       <Link>File.cs</Link>
     </Compile>
+    <Compile Include="..\SparkPost\IClient.cs">
+      <Link>IClient.cs</Link>
+    </Compile>
     <Compile Include="..\SparkPost\InlineImage.cs">
       <Link>InlineImage.cs</Link>
+    </Compile>
+    <Compile Include="..\SparkPost\ITransmissions.cs">
+      <Link>ITransmissions.cs</Link>
     </Compile>
     <Compile Include="..\SparkPost\Options.cs">
       <Link>Options.cs</Link>
@@ -102,8 +108,6 @@
       <Link>SparkPost.nuspec</Link>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -1,6 +1,6 @@
 ﻿namespace SparkPost
 {
-    public class Client
+    public class Client : IClient
     {
         public Client(string apiKey, string apiHost = "https://api.sparkpost.com")
         {

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -12,7 +12,7 @@
         public string ApiKey { get; set; }
         public string ApiHost { get; set; }
 
-        public Transmissions Transmissions { get; }
+        public ITransmissions Transmissions { get; }
         public string Version => "v1";
     }
 }

--- a/src/SparkPost/IClient.cs
+++ b/src/SparkPost/IClient.cs
@@ -1,10 +1,28 @@
 ﻿namespace SparkPost
 {
+    /// <summary>
+    /// Provides access to the SparkPost API.
+    /// </summary>
     public interface IClient
     {
+        /// <summary>
+        /// Gets or sets the key used for requests to the SparkPost API.
+        /// </summary>
         string ApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base URL of the SparkPost API.
+        /// </summary>
         string ApiHost { get; set; }
+
+        /// <summary>
+        /// Gets access to the transmissions resource of the SparkPost API.
+        /// </summary>
         Transmissions Transmissions { get; }
+
+        /// <summary>
+        /// Gets the API version supported by this client.
+        /// </summary>
         string Version { get; }
     }
 }

--- a/src/SparkPost/IClient.cs
+++ b/src/SparkPost/IClient.cs
@@ -1,0 +1,10 @@
+﻿namespace SparkPost
+{
+    public interface IClient
+    {
+        string ApiKey { get; set; }
+        string ApiHost { get; set; }
+        Transmissions Transmissions { get; }
+        string Version { get; }
+    }
+}

--- a/src/SparkPost/IClient.cs
+++ b/src/SparkPost/IClient.cs
@@ -18,7 +18,7 @@
         /// <summary>
         /// Gets access to the transmissions resource of the SparkPost API.
         /// </summary>
-        Transmissions Transmissions { get; }
+        ITransmissions Transmissions { get; }
 
         /// <summary>
         /// Gets the API version supported by this client.

--- a/src/SparkPost/ITransmissions.cs
+++ b/src/SparkPost/ITransmissions.cs
@@ -2,8 +2,16 @@ using System.Threading.Tasks;
 
 namespace SparkPost
 {
+    /// <summary>
+    /// Provides access to the transmissions resource of the SparkPost API.
+    /// </summary>
     public interface ITransmissions
     {
+        /// <summary>
+        /// Sends an email transmission.
+        /// </summary>
+        /// <param name="transmission">The properties of the transmission to send.</param>
+        /// <returns>The response from the API.</returns>
         Task<SendTransmissionResponse> Send(Transmission transmission);
     }
 }

--- a/src/SparkPost/ITransmissions.cs
+++ b/src/SparkPost/ITransmissions.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace SparkPost
+{
+    public interface ITransmissions
+    {
+        Task<SendTransmissionResponse> Send(Transmission transmission);
+    }
+}

--- a/src/SparkPost/SparkPost.csproj
+++ b/src/SparkPost/SparkPost.csproj
@@ -53,7 +53,9 @@
     <Compile Include="Content.cs" />
     <Compile Include="DataMapper.cs" />
     <Compile Include="File.cs" />
+    <Compile Include="IClient.cs" />
     <Compile Include="InlineImage.cs" />
+    <Compile Include="ITransmissions.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Recipient.cs" />

--- a/src/SparkPost/Transmissions.cs
+++ b/src/SparkPost/Transmissions.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace SparkPost
 {
-    public class Transmissions
+    public class Transmissions : ITransmissions
     {
         private readonly Client client;
         private readonly RequestSender requestSender;


### PR DESCRIPTION
This will make it easier to mock SparkPost when unit testing consumers of the .NET API wrapper.

Closes #24 