### PR TITLE
Allow custom http client

### DIFF
--- a/src/SparkPost.Tests/ClientTests.cs
+++ b/src/SparkPost.Tests/ClientTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Net.Http;
+using NUnit.Framework;
+using Should;
+
+namespace SparkPost.Tests
+{
+    public class ClientTests
+    {
+        [TestFixture]
+        public class HttpClientOverridingTests
+        {
+            [SetUp]
+            public void Setup()
+            {
+                client = new Client(null);
+            }
+
+            private Client client;
+
+            [Test]
+            public void By_default_it_should_return_new_http_clients_each_time()
+            {
+                var first = client.CustomSettings.CreateANewHttpClient();
+                var second = client.CustomSettings.CreateANewHttpClient();
+
+                first.ShouldNotBeNull();
+                second.ShouldNotBeNull();
+                first.ShouldNotBeSameAs(second);
+            }
+
+            [Test]
+            public void It_should_allow_the_overriding_of_the_http_client_building()
+            {
+                var httpClient = new HttpClient();
+
+                client.CustomSettings.BuildHttpClientsUsing(() => httpClient);
+
+                client.CustomSettings.CreateANewHttpClient().ShouldBeSameAs(httpClient);
+                client.CustomSettings.CreateANewHttpClient().ShouldBeSameAs(httpClient);
+                client.CustomSettings.CreateANewHttpClient().ShouldBeSameAs(httpClient);
+                client.CustomSettings.CreateANewHttpClient().ShouldBeSameAs(httpClient);
+            }
+        }
+    }
+}

--- a/src/SparkPost.Tests/SparkPost.Tests.csproj
+++ b/src/SparkPost.Tests/SparkPost.Tests.csproj
@@ -85,6 +85,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClientTests.cs" />
     <Compile Include="DataMapperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SuppressionTests.cs" />

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -33,7 +33,7 @@ namespace SparkPost
                 httpClientBuilder = () => new HttpClient();
             }
 
-            internal HttpClient CreateANewHttpClient()
+            public HttpClient CreateANewHttpClient()
             {
                 return httpClientBuilder();
             }

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -5,8 +5,6 @@ namespace SparkPost
 {
     public class Client : IClient
     {
-        private Func<HttpClient> httpClientBuilder;
-
         public Client(string apiKey, string apiHost = "https://api.sparkpost.com")
         {
             ApiKey = apiKey;
@@ -14,7 +12,7 @@ namespace SparkPost
             Transmissions = new Transmissions(this, new RequestSender(this), new DataMapper(Version));
             Suppressions = new Suppressions(this, new RequestSender(this), new DataMapper());
 
-            httpClientBuilder = () => new HttpClient();
+            Settings = new CustomSettings();
         }
 
         public string ApiKey { get; set; }
@@ -24,14 +22,26 @@ namespace SparkPost
         public ISuppressions Suppressions { get; }
         public string Version => "v1";
 
-        internal HttpClient CreateANewHttpClient()
-        {
-            return httpClientBuilder();
-        }
+        public CustomSettings Settings { get; }
 
-        public void BuildHttpClientsUsing(Func<HttpClient> httpClient)
+        public class CustomSettings
         {
-            this.httpClientBuilder = httpClient;
+            private Func<HttpClient> httpClientBuilder;
+
+            public CustomSettings()
+            {
+                httpClientBuilder = () => new HttpClient();
+            }
+
+            internal HttpClient CreateANewHttpClient()
+            {
+                return httpClientBuilder();
+            }
+
+            public void BuildHttpClientsUsing(Func<HttpClient> httpClient)
+            {
+                httpClientBuilder = httpClient;
+            }
         }
     }
 }

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -12,7 +12,7 @@ namespace SparkPost
             Transmissions = new Transmissions(this, new RequestSender(this), new DataMapper(Version));
             Suppressions = new Suppressions(this, new RequestSender(this), new DataMapper());
 
-            Settings = new CustomSettings();
+            CustomSettings = new Settings();
         }
 
         public string ApiKey { get; set; }
@@ -22,13 +22,13 @@ namespace SparkPost
         public ISuppressions Suppressions { get; }
         public string Version => "v1";
 
-        public CustomSettings Settings { get; }
+        public Settings CustomSettings { get; }
 
-        public class CustomSettings
+        public class Settings
         {
             private Func<HttpClient> httpClientBuilder;
 
-            public CustomSettings()
+            public Settings()
             {
                 httpClientBuilder = () => new HttpClient();
             }

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -19,7 +19,7 @@ namespace SparkPost
         public ISuppressions Suppressions { get; }
         public string Version => "v1";
 
-        public HttpClient CreateANewHttpClient()
+        internal HttpClient CreateANewHttpClient()
         {
             return new HttpClient();
         }

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -1,15 +1,20 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 
 namespace SparkPost
 {
     public class Client : IClient
     {
+        private Func<HttpClient> httpClientBuilder;
+
         public Client(string apiKey, string apiHost = "https://api.sparkpost.com")
         {
             ApiKey = apiKey;
             ApiHost = apiHost;
             Transmissions = new Transmissions(this, new RequestSender(this), new DataMapper(Version));
             Suppressions = new Suppressions(this, new RequestSender(this), new DataMapper());
+
+            httpClientBuilder = () => new HttpClient();
         }
 
         public string ApiKey { get; set; }
@@ -21,7 +26,12 @@ namespace SparkPost
 
         internal HttpClient CreateANewHttpClient()
         {
-            return new HttpClient();
+            return httpClientBuilder();
+        }
+
+        public void BuildHttpClientsUsing(Func<HttpClient> httpClient)
+        {
+            this.httpClientBuilder = httpClient;
         }
     }
 }

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -1,4 +1,6 @@
-﻿namespace SparkPost
+﻿using System.Net.Http;
+
+namespace SparkPost
 {
     public class Client : IClient
     {
@@ -16,5 +18,10 @@
         public ITransmissions Transmissions { get; }
         public ISuppressions Suppressions { get; }
         public string Version => "v1";
+
+        public HttpClient CreateANewHttpClient()
+        {
+            return new HttpClient();
+        }
     }
 }

--- a/src/SparkPost/RequestSender.cs
+++ b/src/SparkPost/RequestSender.cs
@@ -25,7 +25,7 @@ namespace SparkPost
 
         public async Task<Response> Send(Request request)
         {
-            using (var c = client.CreateANewHttpClient())
+            using (var c = client.Settings.CreateANewHttpClient())
             {
                 c.BaseAddress = new Uri(client.ApiHost);
                 c.DefaultRequestHeaders.Accept.Clear();

--- a/src/SparkPost/RequestSender.cs
+++ b/src/SparkPost/RequestSender.cs
@@ -25,7 +25,7 @@ namespace SparkPost
 
         public async Task<Response> Send(Request request)
         {
-            using (var c = client.Settings.CreateANewHttpClient())
+            using (var c = client.CustomSettings.CreateANewHttpClient())
             {
                 c.BaseAddress = new Uri(client.ApiHost);
                 c.DefaultRequestHeaders.Accept.Clear();

--- a/src/SparkPost/RequestSender.cs
+++ b/src/SparkPost/RequestSender.cs
@@ -25,7 +25,7 @@ namespace SparkPost
 
         public async Task<Response> Send(Request request)
         {
-            using (var c = new HttpClient())
+            using (var c = client.CreateANewHttpClient())
             {
                 c.BaseAddress = new Uri(client.ApiHost);
                 c.DefaultRequestHeaders.Accept.Clear();


### PR DESCRIPTION
This is meant to resolve #38.

This change allows a user to override how the ```HttpClient``` that the library uses to be changed.  

```c#
client.CustomSettings.BuildHttpClientsUsing(() => new HttpClient());
// or pass your own custom one ^^^
```

Every time a web request is made, it will call the provided function.  If none is provided, it will default to ```new HttpClient()``` like it always has used.

![fullscreen_042116_071900_am](https://cloud.githubusercontent.com/assets/148768/14708545/526c3da6-0791-11e6-8284-028c5f300647.jpg)
