### PR TITLE
Pass substitution data raw

### DIFF
--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -271,6 +271,16 @@ namespace SparkPost.Tests
             }
 
             [Test]
+            public void do_not_alter_the_keys_passed_to_substitution_data()
+            {
+                var key = "TEST";
+                var value = Guid.NewGuid().ToString();
+                transmission.SubstitutionData[key] = value;
+                mapper.ToDictionary(transmission)["substitution_data"]
+                    .CastAs<IDictionary<string, object>>()[key].ShouldEqual(value);
+            }
+
+            [Test]
             public void options()
             {
                 transmission.Options.ClickTracking = true;

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -33,16 +33,18 @@ namespace SparkPost
 
         public virtual IDictionary<string, object> ToDictionary(Transmission transmission)
         {
-            var dictionary = new Dictionary<string, object>
+            var data = new Dictionary<string, object>
             {
+                ["substitution_data"] =
+                    transmission.SubstitutionData != null && transmission.SubstitutionData.Keys.Any()
+                        ? transmission.SubstitutionData
+                        : null,
                 ["recipients"] = transmission.ListId != null
                     ? (object) new Dictionary<string, object> {["list_id"] = transmission.ListId}
                     : transmission.Recipients.Select(ToDictionary)
             };
-            if (transmission.SubstitutionData != null && transmission.SubstitutionData.Keys.Any())
-                dictionary["substitution_data"] = transmission.SubstitutionData;
 
-            var result = WithCommonConventions(transmission, dictionary);
+            var result = WithCommonConventions(transmission, data);
 
             CcHandling.SetAnyCCsInTheHeader(transmission, result);
 

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -33,12 +33,16 @@ namespace SparkPost
 
         public virtual IDictionary<string, object> ToDictionary(Transmission transmission)
         {
-            var result = WithCommonConventions(transmission, new Dictionary<string, object>
+            var dictionary = new Dictionary<string, object>
             {
                 ["recipients"] = transmission.ListId != null
                     ? (object) new Dictionary<string, object> {["list_id"] = transmission.ListId}
                     : transmission.Recipients.Select(ToDictionary)
-            });
+            };
+            if (transmission.SubstitutionData != null && transmission.SubstitutionData.Keys.Any())
+                dictionary["substitution_data"] = transmission.SubstitutionData;
+
+            var result = WithCommonConventions(transmission, dictionary);
 
             CcHandling.SetAnyCCsInTheHeader(transmission, result);
 


### PR DESCRIPTION
This should resolve #49.

The library uses conventions to turn objects into a common form that will work for the SparkPost http API.  It does things like turn ```EmailAddress``` into ```email_address```.

However, the last place we probably want to apply these conventions is the substitution data.  That should be passed raw.

![fullscreen_042716_085402_am](https://cloud.githubusercontent.com/assets/148768/14854505/a02e2950-0c55-11e6-923f-a1f51c135b87.jpg)
