### PR TITLE
Do not alter recipient substitution data keys

### DIFF
--- a/src/SparkPost.Tests/DataMapperTests.cs
+++ b/src/SparkPost.Tests/DataMapperTests.cs
@@ -104,6 +104,16 @@ namespace SparkPost.Tests
             }
 
             [Test]
+            public void do_not_alter_the_keys_passed_to_substitution_data()
+            {
+                var key = "TEST";
+                var value = Guid.NewGuid().ToString();
+                recipient.SubstitutionData[key] = value;
+                mapper.ToDictionary(recipient)["substitution_data"]
+                    .CastAs<IDictionary<string, object>>()[key].ShouldEqual(value);
+            }
+
+            [Test]
             public void The_type_should_be_ignored()
             {
                 recipient.Type = RecipientType.CC;

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -56,6 +56,10 @@ namespace SparkPost
             return WithCommonConventions(recipient, new Dictionary<string, object>()
             {
                 ["type"] = null,
+                ["substitution_data"] =
+                    recipient.SubstitutionData != null && recipient.SubstitutionData.Keys.Any()
+                        ? recipient.SubstitutionData
+                        : null,
             });
         }
 


### PR DESCRIPTION
With this fix, both recipient-specific substitution data  and template substitution data (which was fixed with #52) should both be working as expected.

![fullscreen_042816_061138_am](https://cloud.githubusercontent.com/assets/148768/14884079/126b977a-0d08-11e6-8669-bc1122895c74.jpg)
