### PR TITLE
Create one less dictionary object

### DIFF
--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -112,10 +112,9 @@ namespace SparkPost
 
         private static IDictionary<string, object> RemoveNulls(IDictionary<string, object> dictionary)
         {
-            var newDictionary = new Dictionary<string, object>();
-            foreach (var key in dictionary.Keys.Where(k => dictionary[k] != null))
-                newDictionary[key] = dictionary[key];
-            return newDictionary;
+            var blanks = dictionary.Keys.Where(k => dictionary[k] == null).ToList();
+            foreach (var key in blanks) dictionary.Remove(key);
+            return dictionary;
         }
 
         private IDictionary<string, object> WithCommonConventions(object target, IDictionary<string, object> results = null)


### PR DESCRIPTION
It's ok to just modify the one that is provided.

The dictionary is not returned because we need a new instance, but because I want to be able to just call ```return RemoveNulls(x);```