### PR TITLE
Add tests around the request building

### DIFF
--- a/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AutoMoq.Helpers;
+using NUnit.Framework;
+using Should;
+using SparkPost.RequestSenders;
+
+namespace SparkPost.Tests.RequestSenders
+{
+    public class AsyncRequestSenderTests
+    {
+        public class SendTests : AutoMoqTestFixture<SendTests.AsyncTesting>
+        {
+            private HttpClient httpClient;
+            private Request request;
+
+            [SetUp]
+            public void Setup()
+            {
+                ResetSubject();
+
+                httpClient = new HttpClient();
+
+                var settings = new Client.Settings();
+                settings.BuildHttpClientsUsing(() => httpClient);
+                Mocked<IClient>().Setup(x => x.CustomSettings).Returns(settings);
+                Mocked<IClient>().Setup(x => x.ApiHost).Returns("http://test.com");
+                Mocked<IClient>().Setup(x => x.ApiKey).Returns(Guid.NewGuid().ToString());
+
+                request = new Request();
+            }
+
+            [Test]
+            public async void It_should_return_the_http_response_message_info()
+            {
+                var content = Guid.NewGuid().ToString();
+                Subject.SetupTheResponseWith((r, h) => new HttpResponseMessage(HttpStatusCode.Accepted)
+                {
+                    Content = new StringContent(content)
+                });
+
+                var result = await Subject.Send(request);
+                result.StatusCode.ShouldEqual(HttpStatusCode.Accepted);
+                result.Content.ShouldEqual(content);
+            }
+
+            [Test]
+            public async void It_should_return_the_http_response_message_info_take_2()
+            {
+                var content = Guid.NewGuid().ToString();
+                Subject.SetupTheResponseWith((r, h) => new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent(content)
+                });
+
+                var result = await Subject.Send(request);
+                result.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+                result.ReasonPhrase.ShouldEqual("Not Found");
+                result.Content.ShouldEqual(content);
+            }
+
+            public class AsyncTesting : AsyncRequestSender
+            {
+                private Func<Request, HttpClient, HttpResponseMessage> responseBuilder;
+
+                public AsyncTesting(IClient client) : base(client)
+                {
+                }
+
+                public void SetupTheResponseWith(Func<Request, HttpClient, HttpResponseMessage> responseBuilder)
+                {
+                    this.responseBuilder = responseBuilder;
+                }
+
+                protected override Task<HttpResponseMessage> GetTheResponse(Request request, HttpClient httpClient)
+                {
+                    return Task.FromResult(responseBuilder(request, httpClient));
+                }
+            }
+        }
+    }
+}

--- a/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
@@ -85,6 +85,18 @@ namespace SparkPost.Tests.RequestSenders
                 await Subject.Send(request);
             }
 
+            [Test]
+            public async void It_should_send_the_request_to_the_appropriate_host()
+            {
+                Subject.SetupTheResponseWith((r, h) =>
+                {
+                    h.BaseAddress.ToString().ShouldEqual(apiHost + "/");
+                    return defaultHttpResponseMessage;
+                });
+
+                await Subject.Send(request);
+            }
+
             public class AsyncTesting : AsyncRequestSender
             {
                 private Func<Request, HttpClient, HttpResponseMessage> responseBuilder;

--- a/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
@@ -18,6 +18,7 @@ namespace SparkPost.Tests.RequestSenders
             private Request request;
             private string apiHost;
             private string apiKey;
+            private HttpResponseMessage defaultHttpResponseMessage;
 
             [SetUp]
             public void Setup()
@@ -36,6 +37,11 @@ namespace SparkPost.Tests.RequestSenders
                 Mocked<IClient>().Setup(x => x.ApiKey).Returns(apiKey);
 
                 request = new Request();
+
+                defaultHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Accepted)
+                {
+                    Content = new StringContent(Guid.NewGuid().ToString())
+                };
             }
 
             [Test]
@@ -73,10 +79,7 @@ namespace SparkPost.Tests.RequestSenders
                 Subject.SetupTheResponseWith((r, h) =>
                 {
                     h.DefaultRequestHeaders.Authorization.ToString().ShouldEqual(apiKey);
-                    return new HttpResponseMessage(HttpStatusCode.NotFound)
-                    {
-                        Content = new StringContent(Guid.NewGuid().ToString())
-                    };
+                    return defaultHttpResponseMessage;
                 });
 
                 await Subject.Send(request);

--- a/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -15,6 +16,8 @@ namespace SparkPost.Tests.RequestSenders
         {
             private HttpClient httpClient;
             private Request request;
+            private string apiHost;
+            private string apiKey;
 
             [SetUp]
             public void Setup()
@@ -23,11 +26,14 @@ namespace SparkPost.Tests.RequestSenders
 
                 httpClient = new HttpClient();
 
+                apiHost = "http://test.com";
+                apiKey = Guid.NewGuid().ToString();
+
                 var settings = new Client.Settings();
                 settings.BuildHttpClientsUsing(() => httpClient);
                 Mocked<IClient>().Setup(x => x.CustomSettings).Returns(settings);
-                Mocked<IClient>().Setup(x => x.ApiHost).Returns("http://test.com");
-                Mocked<IClient>().Setup(x => x.ApiKey).Returns(Guid.NewGuid().ToString());
+                Mocked<IClient>().Setup(x => x.ApiHost).Returns(apiHost);
+                Mocked<IClient>().Setup(x => x.ApiKey).Returns(apiKey);
 
                 request = new Request();
             }
@@ -59,6 +65,21 @@ namespace SparkPost.Tests.RequestSenders
                 result.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
                 result.ReasonPhrase.ShouldEqual("Not Found");
                 result.Content.ShouldEqual(content);
+            }
+
+            [Test]
+            public async void It_should_pass_the_api_key()
+            {
+                Subject.SetupTheResponseWith((r, h) =>
+                {
+                    h.DefaultRequestHeaders.Authorization.ToString().ShouldEqual(apiKey);
+                    return new HttpResponseMessage(HttpStatusCode.NotFound)
+                    {
+                        Content = new StringContent(Guid.NewGuid().ToString())
+                    };
+                });
+
+                await Subject.Send(request);
             }
 
             public class AsyncTesting : AsyncRequestSender

--- a/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
+++ b/src/SparkPost.Tests/RequestSenders/AsyncRequestSenderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -91,6 +92,35 @@ namespace SparkPost.Tests.RequestSenders
                 Subject.SetupTheResponseWith((r, h) =>
                 {
                     h.BaseAddress.ToString().ShouldEqual(apiHost + "/");
+                    return defaultHttpResponseMessage;
+                });
+
+                await Subject.Send(request);
+            }
+
+            [Test]
+            public async void It_should_set_the_subaccount_when_the_subaccount_is_not_zero()
+            {
+                Mocked<IClient>().Setup(x => x.SubaccountId).Returns(345);
+                Subject.SetupTheResponseWith((r, h) =>
+                {
+                    var match = h.DefaultRequestHeaders.First(x => x.Key == "X-MSYS-SUBACCOUNT");
+                    match.Value.Count().ShouldEqual(1);
+                    match.Value.First().ShouldEqual("345");
+                    return defaultHttpResponseMessage;
+                });
+
+                await Subject.Send(request);
+            }
+
+            [Test]
+            public async void It_should_NOT_set_a_subaccount_when_the_subaccount_is_zero()
+            {
+                Mocked<IClient>().Setup(x => x.SubaccountId).Returns(0);
+                Subject.SetupTheResponseWith((r, h) =>
+                {
+                    var count = h.DefaultRequestHeaders.Count(x => x.Key == "X-MSYS-SUBACCOUNT");
+                    count.ShouldEqual(0);
                     return defaultHttpResponseMessage;
                 });
 

--- a/src/SparkPost.Tests/SparkPost.Tests.csproj
+++ b/src/SparkPost.Tests/SparkPost.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="RequestMethods\DeleteTests.cs" />
     <Compile Include="RequestMethods\PutTests.cs" />
     <Compile Include="RequestMethods\PostTests.cs" />
+    <Compile Include="RequestSenders\AsyncRequestSenderTests.cs" />
     <Compile Include="RequestSenders\RequestSenderTests.cs" />
     <Compile Include="SuppressionTests.cs" />
     <Compile Include="RequestSenders\SyncRequestSenderTests.cs" />

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -59,7 +59,12 @@ namespace SparkPost
 
             public Settings()
             {
-                httpClientBuilder = () => new HttpClient();
+                httpClientBuilder = () =>
+                {
+                    var httpClient = new HttpClient();
+                    httpClient.DefaultRequestHeaders.Accept.Clear();
+                    return httpClient;
+                };
             }
 
             public SendingModes SendingMode { get; set; }

--- a/src/SparkPost/IClient.cs
+++ b/src/SparkPost/IClient.cs
@@ -44,5 +44,10 @@
         /// Get the custom settings for this client.
         /// </summary>
         Client.Settings CustomSettings { get; }
+
+        /// <summary>
+        /// Gets the sub account.
+        /// </summary>
+        long SubaccountId { get; }
     }
 }

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -20,10 +20,6 @@ namespace SparkPost.RequestSenders
             using (var httpClient = client.CustomSettings.CreateANewHttpClient())
             {
                 httpClient.BaseAddress = new Uri(client.ApiHost);
-
-                // I don't think this is the right spot for this
-                //httpClient.DefaultRequestHeaders.Accept.Clear();
-
                 httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
                 if (client.SubaccountId != 0)
                     httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT", client.SubaccountId.ToString(CultureInfo.InvariantCulture));

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -26,9 +26,7 @@ namespace SparkPost.RequestSenders
 
                 httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
                 if (client.SubaccountId != 0)
-                {
                     httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT", client.SubaccountId.ToString(CultureInfo.InvariantCulture));
-                }
 
                 var result = await GetTheResponse(request, httpClient);
 

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -20,7 +20,10 @@ namespace SparkPost.RequestSenders
             using (var httpClient = client.CustomSettings.CreateANewHttpClient())
             {
                 httpClient.BaseAddress = new Uri(client.ApiHost);
-                httpClient.DefaultRequestHeaders.Accept.Clear();
+
+                // I don't think this is the right spot for this
+                //httpClient.DefaultRequestHeaders.Accept.Clear();
+
                 httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
                 if (client.SubaccountId != 0)
                 {

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace SparkPost.RequestSenders
@@ -15,7 +14,7 @@ namespace SparkPost.RequestSenders
             this.client = client;
         }
 
-        public async virtual Task<Response> Send(Request request)
+        public virtual async Task<Response> Send(Request request)
         {
             using (var httpClient = client.CustomSettings.CreateANewHttpClient())
             {
@@ -23,7 +22,8 @@ namespace SparkPost.RequestSenders
                 httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
 
                 if (client.SubaccountId != 0)
-                    httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT", client.SubaccountId.ToString(CultureInfo.InvariantCulture));
+                    httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT",
+                        client.SubaccountId.ToString(CultureInfo.InvariantCulture));
 
                 var result = await GetTheResponse(request, httpClient);
 

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -8,9 +8,9 @@ namespace SparkPost.RequestSenders
 {
     public class AsyncRequestSender : IRequestSender
     {
-        private readonly Client client;
+        private readonly IClient client;
 
-        public AsyncRequestSender(Client client)
+        public AsyncRequestSender(IClient client)
         {
             this.client = client;
         }

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace SparkPost.RequestSenders
@@ -25,9 +27,7 @@ namespace SparkPost.RequestSenders
                     httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT", client.SubaccountId.ToString(CultureInfo.InvariantCulture));
                 }
 
-                var result = await new RequestMethodFinder(httpClient)
-                    .FindFor(request)
-                    .Execute(request);
+                var result = await GetTheResponse(request, httpClient);
 
                 return new Response
                 {
@@ -36,6 +36,13 @@ namespace SparkPost.RequestSenders
                     Content = await result.Content.ReadAsStringAsync()
                 };
             }
+        }
+
+        protected virtual async Task<HttpResponseMessage> GetTheResponse(Request request, HttpClient httpClient)
+        {
+            return await new RequestMethodFinder(httpClient)
+                .FindFor(request)
+                .Execute(request);
         }
     }
 }

--- a/src/SparkPost/RequestSenders/AsyncRequestSender.cs
+++ b/src/SparkPost/RequestSenders/AsyncRequestSender.cs
@@ -21,6 +21,7 @@ namespace SparkPost.RequestSenders
             {
                 httpClient.BaseAddress = new Uri(client.ApiHost);
                 httpClient.DefaultRequestHeaders.Add("Authorization", client.ApiKey);
+
                 if (client.SubaccountId != 0)
                     httpClient.DefaultRequestHeaders.Add("X-MSYS-SUBACCOUNT", client.SubaccountId.ToString(CultureInfo.InvariantCulture));
 


### PR DESCRIPTION
Here are some unit tests targeting ```AsyncRequestSender```. Given its nature and the fast iterations that started this library, this code was only covered in integration tests.  Now that things are settled and it is pretty clean, it's time to get unit tests on this thing.