### PR TITLE
Added support for inbound domains

### DIFF
--- a/src/SparkPost.Tests/InboundDomainTests.cs
+++ b/src/SparkPost.Tests/InboundDomainTests.cs
@@ -1,0 +1,10 @@
+﻿using NUnit.Framework;
+using Should;
+
+namespace SparkPost.Tests
+{
+    public class InboundDomainTests
+    {
+        
+    }
+}

--- a/src/SparkPost.Tests/SparkPost.Tests.csproj
+++ b/src/SparkPost.Tests/SparkPost.Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="TransmissionTests.cs" />
     <Compile Include="SubaccountTest.cs" />
     <Compile Include="Utilities\SnakeCaseTests.cs" />
+    <Compile Include="InboundDomainTests.cs" />
     <Compile Include="WebhookTests.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -117,7 +118,9 @@
   <ItemGroup>
     <Content Include="License.txt" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -38,6 +38,7 @@ namespace SparkPost
             Webhooks = new Webhooks(this, requestSender, dataMapper);
             Subaccounts = new Subaccounts(this, requestSender, dataMapper);
             MessageEvents = new MessageEvents(this, requestSender);
+            InboundDomains = new InboundDomains(this, requestSender, dataMapper);
 
             CustomSettings = new Settings();
         }
@@ -51,6 +52,7 @@ namespace SparkPost
         public IWebhooks Webhooks { get; }
         public ISubaccounts Subaccounts { get; }
         public IMessageEvents MessageEvents { get; }
+        public IInboundDomains InboundDomains { get; }
         public string Version => "v1";
 
         public Settings CustomSettings { get; }

--- a/src/SparkPost/DataMapper.cs
+++ b/src/SparkPost/DataMapper.cs
@@ -22,6 +22,7 @@ namespace SparkPost
         IDictionary<string, object> ToDictionary(Suppression suppression);
         IDictionary<string, object> ToDictionary(Webhook webhook);
         IDictionary<string, object> ToDictionary(Subaccount subaccount);
+        IDictionary<string, object> ToDictionary(InboundDomain inboundDomain);
         IDictionary<string, object> CatchAll(object anything);
         object GetTheValue(Type propertyType, object value);
         IDictionary<Type, MethodInfo> ToDictionaryMethods();
@@ -123,6 +124,11 @@ namespace SparkPost
         public IDictionary<string, object> ToDictionary(Subaccount subaccount)
         {
             return WithCommonConventions(subaccount);
+        }
+
+        public IDictionary<string, object> ToDictionary(InboundDomain inboundDomain)
+        {
+            return WithCommonConventions(inboundDomain);
         }
 
         public IDictionary<string, object> ToDictionary(MessageEventsQuery query)

--- a/src/SparkPost/IClient.cs
+++ b/src/SparkPost/IClient.cs
@@ -41,6 +41,11 @@
         IMessageEvents MessageEvents { get; }
 
         /// <summary>
+        /// Gets access to the inbound domains resource of the SparkPost API.
+        /// </summary>
+        IInboundDomains InboundDomains { get; }
+
+        /// <summary>
         /// Gets the API version supported by this client.
         /// </summary>
         string Version { get; }

--- a/src/SparkPost/InboundDomain.cs
+++ b/src/SparkPost/InboundDomain.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SparkPost
+{
+    public class InboundDomain
+    {
+        public InboundDomain()
+        {
+        }
+
+        public string Domain { get; set; }
+    }
+}

--- a/src/SparkPost/InboundDomainResponse.cs
+++ b/src/SparkPost/InboundDomainResponse.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace SparkPost
+{
+    public class InboundDomainResponse : Response
+    {
+        public InboundDomain InboundDomain { get; set; }
+
+        public static InboundDomainResponse CreateFromResponse(Response response)
+        {
+            var result = new InboundDomainResponse();
+            LeftRight.SetValuesToMatch(result, response);
+
+            var results = JsonConvert.DeserializeObject<dynamic>(response.Content).results;
+
+            result.InboundDomain = ListInboundDomainResponse.ConvertToAInboundDomain(results);
+
+            return result;
+        }
+    }
+}

--- a/src/SparkPost/InboundDomains.cs
+++ b/src/SparkPost/InboundDomains.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Threading.Tasks;
+using SparkPost.RequestSenders;
+
+namespace SparkPost
+{
+    public interface IInboundDomains
+    {
+        Task<ListInboundDomainResponse> List(object query = null);
+        Task<Response> Create(InboundDomain inboundDomain);
+        Task<InboundDomainResponse> Retrieve(string domain);
+        Task<bool> Delete(string domain);
+    }
+
+    public class InboundDomains : IInboundDomains
+    {
+        private readonly IClient client;
+        private readonly IDataMapper dataMapper;
+        private readonly IRequestSender requestSender;
+
+        public InboundDomains(IClient client, IRequestSender requestSender, IDataMapper dataMapper)
+        {
+            this.client = client;
+            this.requestSender = requestSender;
+            this.dataMapper = dataMapper;
+        }
+
+        public async Task<ListInboundDomainResponse> List(object query = null)
+        {
+            if (query == null) query = new {};
+            var request = new Request
+            {
+                Url = $"/api/{client.Version}/inbound-domains",
+                Method = "GET",
+                Data = query
+            };
+
+            var response = await requestSender.Send(request);
+            if (response.StatusCode != HttpStatusCode.OK) throw new ResponseException(response);
+
+            return ListInboundDomainResponse.CreateFromResponse(response);
+        }
+
+        public async Task<InboundDomainResponse> Retrieve(string domain)
+        {
+            var request = new Request
+            {
+                Url = $"/api/{client.Version}/inbound-domains/{domain}",
+                Method = "GET"
+            };
+
+            var response = await requestSender.Send(request);
+            if (response.StatusCode != HttpStatusCode.OK) throw new ResponseException(response);
+
+            return InboundDomainResponse.CreateFromResponse(response);
+        }
+
+        public async Task<Response> Create(InboundDomain inboundDomain)
+        {
+            var request = new Request
+            {
+                Url = $"api/{client.Version}/inbound-domains",
+                Method = "POST",
+                Data = dataMapper.ToDictionary(inboundDomain)
+            };
+
+            var response = await requestSender.Send(request);
+            if (response.StatusCode != HttpStatusCode.OK) throw new ResponseException(response);
+
+            var createInboundDomainResponse = new Response();
+            LeftRight.SetValuesToMatch(createInboundDomainResponse, response);
+            return createInboundDomainResponse;
+        }
+
+        public async Task<bool> Delete(string domain)
+        {
+            var request = new Request
+            {
+                Url = $"/api/{client.Version}/inbound-domains/{domain}",
+                Method = "DELETE"
+            };
+
+            var response = await requestSender.Send(request);
+            return response.StatusCode == HttpStatusCode.OK;
+        }
+    }
+}

--- a/src/SparkPost/ListInboundDomainResponse.cs
+++ b/src/SparkPost/ListInboundDomainResponse.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SparkPost
+{
+    public class ListInboundDomainResponse : Response
+    {
+        public IEnumerable<InboundDomain> InboundDomains { get; set; }
+
+        public static ListInboundDomainResponse CreateFromResponse(Response response)
+        {
+            var result = new ListInboundDomainResponse();
+            LeftRight.SetValuesToMatch(result, response);
+
+            var results = JsonConvert.DeserializeObject<dynamic>(result.Content).results;
+            var inboundDomains = new List<InboundDomain>();
+            foreach(var r in results)
+                inboundDomains.Add(ConvertToAInboundDomain(r));
+
+            result.InboundDomains = inboundDomains;
+            return result;
+        }
+
+        internal static InboundDomain ConvertToAInboundDomain(dynamic r)
+        {
+            var inboundDomain = new InboundDomain
+            {
+                Domain = r.domain
+            };
+            return inboundDomain;
+        }
+    }
+}

--- a/src/SparkPost/SparkPost.csproj
+++ b/src/SparkPost/SparkPost.csproj
@@ -59,11 +59,13 @@
     <Compile Include="IMessageEvents.cs" />
     <Compile Include="IValueMapper.cs" />
     <Compile Include="ListMessageEventsResponse.cs" />
+    <Compile Include="ListInboundDomainResponse.cs" />
     <Compile Include="MessageEvent.cs" />
     <Compile Include="MessageEvents.cs" />
     <Compile Include="MessageEventsQuery.cs" />
     <Compile Include="MessageEventType.cs" />
     <Compile Include="PageLink.cs" />
+    <Compile Include="InboundDomainResponse.cs" />
     <Compile Include="Utilities\SnakeCase.cs" />
     <Compile Include="ValueMappers\AnonymousValueMapper.cs" />
     <Compile Include="ValueMappers\BooleanValueMapper.cs" />
@@ -126,7 +128,9 @@
     <Compile Include="ValueMappers\MapASingleItemUsingToDictionary.cs" />
     <Compile Include="ValueMappers\StringObjectDictionaryValueMapper.cs" />
     <Compile Include="ValueMappers\StringStringDictionaryValueMapper.cs" />
+    <Compile Include="InboundDomain.cs" />
     <Compile Include="Webhook.cs" />
+    <Compile Include="InboundDomains.cs" />
     <Compile Include="Webhooks.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Sorry for dumping this on you without a PR, but I needed this functionality for myself so I wrote it quickly.

Here is the test harness that I used to test:

        static void Main(string[] args)
        {
            var apiKey = "<API Key>";
            var inboundDomain = "test.example.com";

            var client = new SparkPost.Client(apiKey);
            var create = client.InboundDomains.Create(new InboundDomain { Domain = inboundDomain }).Result;

            var list = client.InboundDomains.List().Result;
            Debug.Assert(list.InboundDomains.Count() == 1);
            Debug.Assert(list.InboundDomains.First().Domain == inboundDomain);

            var retrieve = client.InboundDomains.Retrieve(inboundDomain).Result;
            Debug.Assert(retrieve.InboundDomain.Domain == inboundDomain);

            var delete = client.InboundDomains.Delete(inboundDomain).Result;
            Debug.Assert(delete);
        }
