### PR TITLE
Docker instance to build & deploy to nuget

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM mono
+MAINTAINER Darren Cauthon <darren@cauthon.com>
+
+RUN apt-get update
+RUN apt-get install -y wget git dos2unix
+
+WORKDIR /
+
+RUN git clone https://github.com/SparkPost/csharp-sparkpost.git
+
+WORKDIR /csharp-sparkpost/src
+
+ADD build_and_deploy.sh /csharp-sparkpost/src
+RUN chmod 777 build_and_deploy.sh
+RUN dos2unix build_and_deploy.sh
+
+CMD /csharp-sparkpost/src/build_and_deploy.sh

--- a/docker/build_and_deploy.sh
+++ b/docker/build_and_deploy.sh
@@ -1,0 +1,10 @@
+git pull origin master
+
+nuget restore
+xbuild /p:Configuration=Release
+
+nuget pack SparkPost/SparkPost.nuspec -Prop Configuration=Release
+
+PACKAGE=$(ls *.nupkg)
+
+nuget push $PACKAGE $APIKEY

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,17 @@
+## Build & Deploy via Docker & Nuget
+
+This docker container will pull the latest version of this library, create a nuget package, and deploy it to Nuget.
+
+The only thing is needs is a valid Nuget API key, from someone that has rights to publish the package to Nuget.
+
+```
+cd docker
+docker build .  # this will produce a hash key, say 12345678
+docker run -e "APIKEY=your_nuget_key_here" 12345678
+```
+
+This container has been registered on Docker Hub, and can be run like so:
+
+```
+docker run -e "APIKEY=your_nuget_key_here" darrencauthon/csharp-sparkpost
+```


### PR DESCRIPTION
## Build & Deploy via Docker & Nuget

This docker container will pull the latest version of this library, create a nuget package, and deploy it to Nuget.

The only thing is needs is a valid Nuget API key, from someone that has rights to publish the package to Nuget.

```
cd docker
docker build .  # this will produce a hash key, say 12345678
docker run -e "APIKEY=your_nuget_key_here" 12345678
```

This container has been registered on Docker Hub, and can be run like so:

```
docker run -e "APIKEY=your_nuget_key_here" darrencauthon/csharp-sparkpost
```