### PR TITLE
Manually select files

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Darren Cauthon <darren@cauthon.com>
 RUN apt-get update
 RUN apt-get install -y wget git dos2unix
 
+RUN nuget update -self
+
 WORKDIR /
 
 RUN git clone https://github.com/SparkPost/csharp-sparkpost.git

--- a/src/SparkPost/SparkPost.nuspec
+++ b/src/SparkPost/SparkPost.nuspec
@@ -19,5 +19,6 @@
   </metadata>
   <files>
     <file src="/bin/Release/SparkPost.dll" target="lib/net45" />
+    <file src="/bin/Release/SparkPost.xml" target="lib/net45" />
   </files>
 </package>

--- a/src/SparkPost/SparkPost.nuspec
+++ b/src/SparkPost/SparkPost.nuspec
@@ -17,4 +17,7 @@
       <dependency id="Newtonsoft.Json" version="(6.0,)" />
     </dependencies>
   </metadata>
+  <files>
+    <file src="bin\Release\SparkPost.dll" target="lib" />
+  </files>
 </package>

--- a/src/SparkPost/SparkPost.nuspec
+++ b/src/SparkPost/SparkPost.nuspec
@@ -18,6 +18,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\SparkPost.dll" target="lib" />
+    <file src="/bin/Release/SparkPost.dll" target="lib/net45" />
   </files>
 </package>

--- a/src/SparkPost/SparkPost.nuspec
+++ b/src/SparkPost/SparkPost.nuspec
@@ -18,7 +18,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="/bin/Release/SparkPost.dll" target="lib/net45" />
-    <file src="/bin/Release/SparkPost.xml" target="lib/net45" />
+    <file src="bin/Release/SparkPost.dll" target="lib/net45" />
+    <file src="bin/Release/SparkPost.xml" target="lib/net45" />
   </files>
 </package>


### PR DESCRIPTION
It seems that when using Mono to build the package via the nuspec, each dll has to be added manually.

Plus, the nuget commandline version that comes with Mono (today) is very old. Upgraded that to the most recent before pushing the library.