### PR TITLE
If a subaccount is passed in the constructor, SET IT.

### DIFF
--- a/src/SparkPost.Tests/ClientTests.cs
+++ b/src/SparkPost.Tests/ClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using NUnit.Framework;
 using Should;
 
@@ -51,6 +52,13 @@ namespace SparkPost.Tests
             public void it_should_have_inbound_domains()
             {
                 client.InboundDomains.ShouldNotBeNull();
+            }
+
+            [Test]
+            public void It_should_set_any_subaccount_id_passed_to_it()
+            {
+                (new Client(Guid.NewGuid().ToString(), 1234))
+                    .SubaccountId.ShouldEqual(1234);
             }
         }
     }

--- a/src/SparkPost/Client.cs
+++ b/src/SparkPost/Client.cs
@@ -27,6 +27,7 @@ namespace SparkPost
         {
             ApiKey = apiKey;
             ApiHost = apiHost;
+            SubaccountId = subAccountId;
 
             var dataMapper = new DataMapper(Version);
             var asyncRequestSender = new AsyncRequestSender(this, dataMapper);


### PR DESCRIPTION
Resharper caught this for me.  Noticed the subaccount being passed in the constructor was gray, as it was unused.  Seems like that would be a helpful thing to use.  Sorry for the goof.