### PR TITLE
Make sync explicit

### DIFF
--- a/examples/BCC/Program.cs
+++ b/examples/BCC/Program.cs
@@ -52,7 +52,7 @@ namespace SparkPost.Examples
             var client = new Client(settings["apikey"]);
             client.CustomSettings.SendingMode = SendingModes.Sync;
 
-            client.Transmissions.Send(trans);
+            var response = client.Transmissions.Send(trans);
 
             Console.WriteLine("done");
         }

--- a/examples/BCC/Program.cs
+++ b/examples/BCC/Program.cs
@@ -48,7 +48,11 @@ namespace SparkPost.Examples
             trans.Content.Headers.Add("CC", ccAddr);
 
             Console.Write("Sending BCC / CC sample mail...");
-            new Client(settings["apikey"]).Transmissions.Send(trans).Wait();
+
+            var client = new Client(settings["apikey"]);
+
+            client.Transmissions.Send(trans).Wait();
+
             Console.WriteLine("done");
         }
     }

--- a/examples/BCC/Program.cs
+++ b/examples/BCC/Program.cs
@@ -50,8 +50,9 @@ namespace SparkPost.Examples
             Console.Write("Sending BCC / CC sample mail...");
 
             var client = new Client(settings["apikey"]);
+            client.CustomSettings.SendingMode = SendingModes.Sync;
 
-            client.Transmissions.Send(trans).Wait();
+            client.Transmissions.Send(trans);
 
             Console.WriteLine("done");
         }

--- a/examples/CC/Program.cs
+++ b/examples/CC/Program.cs
@@ -40,7 +40,7 @@ namespace SparkPost.Examples
             var client = new Client(settings["apikey"]);
             client.CustomSettings.SendingMode = SendingModes.Sync;
 
-            client.Transmissions.Send(trans);
+            var response = client.Transmissions.Send(trans);
 
             Console.WriteLine("done");
         }

--- a/examples/CC/Program.cs
+++ b/examples/CC/Program.cs
@@ -36,7 +36,11 @@ namespace SparkPost.Examples
             trans.Content.Headers.Add("CC", ccAddr);
 
             Console.Write("Sending CC sample mail...");
-            new Client(settings["apikey"]).Transmissions.Send(trans).Wait();
+
+            var client = new Client(settings["apikey"]);
+
+            client.Transmissions.Send(trans).Wait();
+
             Console.WriteLine("done");
         }
     }

--- a/examples/CC/Program.cs
+++ b/examples/CC/Program.cs
@@ -38,8 +38,9 @@ namespace SparkPost.Examples
             Console.Write("Sending CC sample mail...");
 
             var client = new Client(settings["apikey"]);
+            client.CustomSettings.SendingMode = SendingModes.Sync;
 
-            client.Transmissions.Send(trans).Wait();
+            client.Transmissions.Send(trans);
 
             Console.WriteLine("done");
         }

--- a/examples/SendInline/Program.cs
+++ b/examples/SendInline/Program.cs
@@ -37,7 +37,11 @@ namespace SparkPost.Examples
                 "<html><body><h2>Greetings {{firstName or 'recipient'}}</h2><p>Hello from C# land.</p></body></html>";
 
             Console.Write("Sending mail...");
-            new Client(settings["apikey"]).Transmissions.Send(trans).Wait();
+
+            var client = new Client(settings["apikey"]);
+
+            client.Transmissions.Send(trans).Wait();
+
             Console.WriteLine("done");
         }
     }

--- a/examples/SendInline/Program.cs
+++ b/examples/SendInline/Program.cs
@@ -41,7 +41,7 @@ namespace SparkPost.Examples
             var client = new Client(settings["apikey"]);
             client.CustomSettings.SendingMode = SendingModes.Sync;
 
-            client.Transmissions.Send(trans);
+            var response = client.Transmissions.Send(trans);
 
             Console.WriteLine("done");
         }

--- a/examples/SendInline/Program.cs
+++ b/examples/SendInline/Program.cs
@@ -39,8 +39,9 @@ namespace SparkPost.Examples
             Console.Write("Sending mail...");
 
             var client = new Client(settings["apikey"]);
+            client.CustomSettings.SendingMode = SendingModes.Sync;
 
-            client.Transmissions.Send(trans).Wait();
+            client.Transmissions.Send(trans);
 
             Console.WriteLine("done");
         }

--- a/examples/SendTemplate/Program.cs
+++ b/examples/SendTemplate/Program.cs
@@ -51,7 +51,7 @@ namespace SparkPost.Examples
             var client = new Client(settings["apikey"]);
             client.CustomSettings.SendingMode = SendingModes.Sync;
 
-            client.Transmissions.Send(trans);
+            var response = client.Transmissions.Send(trans);
 
             Console.WriteLine("done");
         }

--- a/examples/SendTemplate/Program.cs
+++ b/examples/SendTemplate/Program.cs
@@ -47,7 +47,11 @@ namespace SparkPost.Examples
             trans.Content.TemplateId = "orderSummary";
 
             Console.Write("Sending mail...");
-            new Client(settings["apikey"]).Transmissions.Send(trans).Wait();
+
+            var client = new Client(settings["apikey"]);
+
+            client.Transmissions.Send(trans).Wait();
+
             Console.WriteLine("done");
         }
     }

--- a/examples/SendTemplate/Program.cs
+++ b/examples/SendTemplate/Program.cs
@@ -49,8 +49,9 @@ namespace SparkPost.Examples
             Console.Write("Sending mail...");
 
             var client = new Client(settings["apikey"]);
+            client.CustomSettings.SendingMode = SendingModes.Sync;
 
-            client.Transmissions.Send(trans).Wait();
+            client.Transmissions.Send(trans);
 
             Console.WriteLine("done");
         }


### PR DESCRIPTION
@ewandennis 

I'm switching out the ```.Wait()``` call here with a setting to go to ```Sync``` mode.  

I'm doing this because there are areas, where for reasons I don't want to think about, the ```.Wait()``` call will hang.  Like a MVC action.  I've fielded multiple questions on this, which is why I stopped suggesting people use ```Wait()``` or "figure it out."  This mode will perform the "wait" in a way that will not cause a hang in a MVC action.